### PR TITLE
Fjernet alt annet enn stopPlace fra APIet

### DIFF
--- a/src/app/(white)/admin/create-game/page.tsx
+++ b/src/app/(white)/admin/create-game/page.tsx
@@ -142,7 +142,7 @@ export default function AdminCreateJourney() {
             try {
                 if (inputValue.length < 2) return []
                 const response = await fetch(
-                    `https://api.entur.io/geocoder/v1/autocomplete?text=${inputValue}&size=20&lang=no&layer=venue`,
+                    `https://api.entur.io/geocoder/v1/autocomplete?text=${inputValue}&size=20&lang=no&layers=venue`,
                 )
                 const data: TGeoresponse = await response.json()
                 const mappedData = data.features.map((feature) => {
@@ -152,10 +152,7 @@ export default function AdminCreateJourney() {
                         value: id ?? '',
                     }
                 })
-                const filteredData = mappedData.filter(
-                    (item) => !/^NSR:GroupOfStopPlaces:\d+$/.test(item.value),
-                )
-                return filteredData
+                return mappedData
             } catch (error) {
                 if (error === 'AbortError') throw error
                 console.error('Error fetching data:', error)


### PR DESCRIPTION
## Pull Request Template

### PR Type 🍏

What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[x] API
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation content changes
[ ] Tests
[ ] Other
```

[Kanban Link](https://www.notion.so/bekks/742fa46fd71e47728aff33e5a32e125e?v=4fe4766ee0f54d348a595b3864658662&p=7c65c5aafd434e92a60b33a8ac1e77f2&pm=s)

### Context 🤷‍♀️
It was not possible to create a new game, because the fetchItems function to the stopPlace API fetched all types of stops not just stop places.

### What's new? 👶
Added layers=venue to the end of the API url to only get stop places.

### Screenshots 🖼️

