### PR TITLE
Use db time in game

### DIFF
--- a/src/app/(light)/game/[eventName]/page.tsx
+++ b/src/app/(light)/game/[eventName]/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import { useParams } from 'next/navigation'
 
 import { Heading1 } from '@entur/typography'
@@ -10,6 +10,7 @@ import Game from '@/components/Game/GameScreen'
 import GameNavBar from '@/components/NavBar/GameNavBar'
 import { getEventByEventName } from '@/lib/api/eventApi'
 import { Event } from '@/lib/types/types'
+import useSWR from 'swr'
 
 export default function GamePage(): JSX.Element {
     const [startTimer] = useState<number>(Date.now())
@@ -18,64 +19,50 @@ export default function GamePage(): JSX.Element {
     const [totalHp, setTotalHp] = useState<number>(2)
 
     const { eventName }: { eventName: string } = useParams()
-    const [event, setEvent] = useState<Event | null>(null)
-    const [isEventError, setEventError] = useState<boolean>(false)
 
-    useEffect(() => {
-        async function getEvent() {
-            if (!eventName) {
-                setEventError(true)
-                return
-            }
-
-            const eventJson = await getEventByEventName(eventName)
-            if (eventJson === null) {
-                setEventError(true)
-                return
-            } else {
-                setEventError(false)
-                setEvent(eventJson)
-            }
-        }
-        getEvent()
-    }, [])
-
-    if (isEventError) {
-        // TODO: redirect to main screen
-        return (
-            <div className="max-w-screen-xl xl:ml-72 xl:mr-40 ml-10 mr-10">
-                <Heading1>Event ikke funnet</Heading1>
-            </div>
-        )
-    }
-    if (event === null) {
-        //TODO: errorHandling dersom event=== null for lenge. "event not found" bør vises i stedet etter en viss tid
-        return <Loader>Laster...</Loader>
-    }
+    const {
+        data: event,
+        isLoading,
+        error: eventError,
+    } = useSWR<Event | null>(['/events', eventName], () =>
+        getEventByEventName(eventName),
+    )
 
     return (
-        <main className="flex flex-col">
-            <div className="sm:sticky top-20">
-                <GameNavBar
-                    healthLeft={totalHp + 1}
-                    numLegs={numLegs}
-                    timeDescription={timeDescription}
-                />
-            </div>
-            <div className="max-w-screen-xl xl:ml-72 xl:mr-40 ml-10 mr-10">
-                <Game
-                    name={''}
-                    event={event}
-                    startTimer={startTimer}
-                    // eslint-disable-next-line @typescript-eslint/no-empty-function
-                    handleWinner={() => {}}
-                    totalHp={totalHp}
-                    setTotalHp={setTotalHp}
-                    numLegs={numLegs}
-                    setNumLegs={setNumLegs}
-                    setTimeDescription={setTimeDescription}
-                />
-            </div>
-        </main>
+        <>
+            {isLoading ? (
+                <Loader>Laster spill</Loader>
+            ) : eventError ? (
+                <div className="max-w-screen-xl xl:ml-72 xl:mr-40 ml-10 mr-10">
+                    <Heading1>Spill ikke funnet</Heading1>
+                </div>
+            ) : (
+                event && (
+                    <main className="flex flex-col">
+                        <div className="sm:sticky top-20">
+                            <GameNavBar
+                                healthLeft={totalHp + 1}
+                                numLegs={numLegs}
+                                timeDescription={timeDescription}
+                            />
+                        </div>
+                        <div className="max-w-screen-xl xl:ml-72 xl:mr-40 ml-10 mr-10">
+                            <Game
+                                name={''}
+                                event={event}
+                                startTimer={startTimer}
+                                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                                handleWinner={() => {}}
+                                totalHp={totalHp}
+                                setTotalHp={setTotalHp}
+                                numLegs={numLegs}
+                                setNumLegs={setNumLegs}
+                                setTimeDescription={setTimeDescription}
+                            />
+                        </div>
+                    </main>
+                )
+            )}
+        </>
     )
 }

--- a/src/components/Game/GameScreen.tsx
+++ b/src/components/Game/GameScreen.tsx
@@ -69,7 +69,16 @@ function GameScreen({
     const [usedMode, setUsedMode] = useState<QueryMode[]>([])
     const { getWalkableStopPlaces, getDepartures, getStopsOnLine } =
         useEnturService()
-    const [startTime, setStartTime] = useState<Date>(new Date())
+
+    const eventStartDate = new Date(
+        Number(event.startTime[0]),
+        Number(event.startTime[1]) - 1,
+        Number(event.startTime[2]),
+        Number(event.startTime[3]),
+        Number(event.startTime[4]),
+    )
+
+    const [startTime, setStartTime] = useState<Date>(eventStartDate)
     const [currentTime, setCurrentTime] = useState<Date>(startTime)
     // TravelLegStart states
     const [travelLegsMode, setTravelLegsMode] = useState<QueryMode[]>([])
@@ -82,7 +91,7 @@ function GameScreen({
         setStartLocation(event.startLocation)
         setTravelLegs([event.startLocation])
         setEndLocation(event.endLocation)
-        setStartTime(new Date())
+        setStartTime(eventStartDate)
     }, [event])
 
     useEffect(() => {


### PR DESCRIPTION
## Pull Request Template

### PR Type 🍏

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] API
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation content changes
[ ] Tests
[ ] Other
```

[Kanban Link](https://www.notion.so/bekks/Tiden-som-settes-i-admin-settes-i-spillet-3a41d9990dc24872818a498a28c89014?pvs=4)
[Kanban Link Loading ticket](https://www.notion.so/bekks/Loading-av-spill-event-e881b4f644d1445eab914df131652f7c?pvs=4)

### Context 🤷‍♀️

Tiden som vises og brukes i spillet er nå satt til date.now, som betyr at den alltid bruker nåværende tid. Vi setter en starttid i event, men denne brukes ikke.

I tillegg er det ikke noe loading feedback når man trykker kjør fra landingssiden som bruker.

### What's new? 👶

Spillet bruker nå starttid fra event til å vise tid, hente reisealternativer og beregne poengsum.
En loader vises når bruker trykker kjør.

### Screenshots 🖼️

Bilde av loader fra landingsside etter man trykker på kjør!
![Skjermbilde 2024-07-15 kl  16 25 12](https://github.com/user-attachments/assets/095d1eb6-58da-4cfc-9243-9dcdab9627e6)

