### PR TITLE
Add dynamic walking distance in game

### DIFF
--- a/src/components/Game/components/DepartureAndOnLinePickerModal.tsx
+++ b/src/components/Game/components/DepartureAndOnLinePickerModal.tsx
@@ -6,6 +6,7 @@ import { Modal } from '@entur/modal'
 import { getModeIcon } from '@/lib/utils/transportMapper'
 import { formatTime } from '@/lib/utils/dateFnsUtils'
 import { StopAndTime } from '@/components/Game/Game'
+import { generateKey } from '@/lib/utils/generateUniqueKey'
 
 type Props = {
     departures: Departure[]
@@ -114,7 +115,7 @@ export const DepartureAndOnLinePickerModal = ({
                             {stopsOnLine.map((stop) => (
                                 <ChoiceChip
                                     className="select-none"
-                                    key={stop.stopPlace.id}
+                                    key={generateKey(String(stop.stopPlace.id))}
                                     value={stop.stopPlace.id}
                                     onClick={() => {
                                         selectStopOnLine(stop)

--- a/src/lib/api/journeyPlannerApi.ts
+++ b/src/lib/api/journeyPlannerApi.ts
@@ -19,6 +19,24 @@ export async function getTripInfo(
     return response.json()
 }
 
+export async function getWalkTrip(
+    query: string,
+    variables: Partial<TripQueryVariables>,
+) {
+    const response = await fetch(
+        'https://api.entur.io/journey-planner/v3/graphql',
+        {
+            method: 'POST',
+            headers: {
+                'ET-Client-Name': 'enturspillet',
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ query, variables }),
+        },
+    )
+    return response.json()
+}
+
 export const fetchDropdownItems = async (
     inputValue: string,
 ): Promise<NormalizedDropdownItemType[]> => {

--- a/src/lib/constants/queries.ts
+++ b/src/lib/constants/queries.ts
@@ -38,3 +38,27 @@ query getTripInfo($from: Location!, $to: Location!, $dateTime: DateTime!, $modes
   }
 }
 `
+
+export const walkingDistanceTripQuery = `
+query getTripInfo($from: Location!, $to: Location!, $dateTime: DateTime!, $modes: Modes!) {
+  trip(from: $from, to: $to, numTripPatterns: 1, dateTime: $dateTime, modes: $modes) {
+    tripPatterns {
+      streetDistance
+      legs {
+        id
+        mode
+      }
+    }
+  }
+}
+`
+
+export const walkOnlyTripQuery = `
+query getTripInfo($from: Location!, $to: Location!) {
+  trip(from: $from, to: $to, numTripPatterns: 1, modes: {directMode: foot, transportModes: []}) {
+    tripPatterns {
+      walkTime
+    }
+  }
+}
+`

--- a/src/lib/hooks/useEnturService.ts
+++ b/src/lib/hooks/useEnturService.ts
@@ -55,6 +55,7 @@ async function getStopsOnLine(
 
 async function getWalkableStopPlaces(
     currentStopPlace: StopPlace,
+    maximumDistance?: number,
 ): Promise<StopPlaceDetails[]> {
     if (!currentStopPlace.latitude || !currentStopPlace.longitude) {
         return []
@@ -67,7 +68,7 @@ async function getWalkableStopPlaces(
         },
         {
             filterByPlaceTypes: [TypeName.STOP_PLACE],
-            maximumDistance: 500,
+            maximumDistance: maximumDistance ? Math.ceil(maximumDistance) : 500,
         },
     )
 

--- a/src/lib/types/types.ts
+++ b/src/lib/types/types.ts
@@ -97,6 +97,8 @@ export type Leg = {
 type TripPattern = {
     duration: number
     expectedStartTime: string
+    streetDistance?: number
+    walkTime?: number
     legs: Leg[]
 }
 

--- a/src/lib/utils/transportMapper.tsx
+++ b/src/lib/utils/transportMapper.tsx
@@ -35,7 +35,7 @@ export function getModeIcon(mode: QueryMode): JSX.Element | null {
 export function getModeTranslation(mode: QueryMode): string {
     switch (mode) {
         case 'foot':
-            return 'Gange (maks 500 m)'
+            return 'Gange'
         case 'bus':
             return 'Buss'
         case 'coach':


### PR DESCRIPTION
## Pull Request Template

### PR Type 🍏

What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] API
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation content changes
[ ] Tests
[ ] Other
```

[Kanban Link](https://www.notion.so/bekks/Utforske-hvordan-gangavstand-fungerer-812d064d147a427fada5615064ae1fe6?pvs=4)

### Context 🤷‍♀️

Gangavstand er alltid satt til 500m. Det betyr at hvis det ikke er direkte transport til endestasjon og nærmeste stopp er over 500m er det ikke mulig å nå mål.

### What's new? 👶

Gangavstand i spillet som bruker kan velge er nå dynamisk. Den fungerer på følgende måte:
- Det hentes ut en reise fra start til mål
  - I denne reisen finnes det en streetDistance som sier total lengde man må gå i reisen. Dette settes som max distance man kan gå for alle ledd i reisen
- For hvert sted man er hentes nærmeste stoppesteder med max distance som argument
- Deretter gjøres det et kall per nærmeste stoppested for å sjekke walkTime (tid det tar å gå fra start til mål) mellom nåværende stoppested og nærmeste stoppested
  - Denne tiden blir så brukt i spillet for å legge til antall tid brukt

### Screenshots 🖼️

Add pictures if applicable.
