### PR TITLE
added check to open modal only if no event already is active

### DIFF
--- a/src/app/(white)/admin/create-game/page.tsx
+++ b/src/app/(white)/admin/create-game/page.tsx
@@ -33,6 +33,7 @@ import { tripQuery, visualSolutionTripQuery } from '@/lib/constants/queries'
 import useSWR from 'swr'
 import RouteSuggestion from '@/components/RouteSuggestion'
 import { Modal } from '@entur/modal'
+import { useEventName } from '@/lib/hooks/useEventName'
 
 export default function AdminCreateJourney() {
     const router = useRouter()
@@ -53,6 +54,7 @@ export default function AdminCreateJourney() {
 
     const [isError, setError] = useState<boolean>(false)
     const [responseStatus, setResponseStatus] = useState<number | null>(null)
+    const { eventName } = useEventName()
 
     useEffect(() => {
         const handleCreateEvent = async () => {
@@ -143,6 +145,14 @@ export default function AdminCreateJourney() {
         }
 
         fetchTripInfo()
+    }
+
+    const handleCheckActive = async () => {
+        if (eventName === null) {
+            handleOnClick()
+        } else {
+            setOpen(true)
+        }
     }
 
     const variables = {
@@ -337,7 +347,8 @@ export default function AdminCreateJourney() {
                         width="auto"
                         variant="primary"
                         size="medium"
-                        onClick={() => setOpen(true)}
+                        onClick={handleCheckActive}
+                        loading={loading}
                     >
                         Opprett spill
                     </Button>


### PR DESCRIPTION
## Pull Request Template

### PR Type 🍏

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] API
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation content changes
[ ] Tests
[ ] Other
```

[Kanban Link](https://www.notion.so/bekks/742fa46fd71e47728aff33e5a32e125e?v=4fe4766ee0f54d348a595b3864658662&p=77a1bc33593740e684520852b5981e09&pm=s)

### Context 🤷‍♀️
When pressing the create game button on the create game page in the admin panel a modal appeared regardless of whether an event already was active or not.

### What's new? 👶
A handle function that checks whether an event is active and handles the opening of the modal thereafter.

