### PR TITLE
Fix total travel time

### DIFF
--- a/src/app/(dark)/game/[eventName]/page.tsx
+++ b/src/app/(dark)/game/[eventName]/page.tsx
@@ -45,6 +45,7 @@ export default function GamePage(): JSX.Element {
                 Number(event.startTime[2]),
                 Number(event.startTime[3]),
                 Number(event.startTime[4]),
+                Number(event.startTime?.[5]) || 0,
             )
             setStartTime(eventStartDate)
             setCurrentTime(eventStartDate)

--- a/src/app/(white)/admin/create-game/page.tsx
+++ b/src/app/(white)/admin/create-game/page.tsx
@@ -27,7 +27,10 @@ import {
 import { useRouter } from 'next/navigation'
 import { SmallAlertBox, useToast } from '@entur/alert'
 import { createEvent } from '@/lib/api/eventApi'
-import { formatDateTime } from '@/lib/utils/dateFnsUtils'
+import {
+    formatDateTime,
+    formatIntervalToSeconds,
+} from '@/lib/utils/dateFnsUtils'
 import { getTripInfo, fetchDropdownItems } from '@/lib/api/journeyPlannerApi'
 import { tripQuery, visualSolutionTripQuery } from '@/lib/constants/queries'
 import useSWR from 'swr'
@@ -128,7 +131,10 @@ export default function AdminCreateJourney() {
                         endLocationId: selectedGoal?.value,
                         startTime: formattedDateTime,
                         optimalStepNumber: tripPattern.legs.length,
-                        optimalTravelTime: tripPattern.duration,
+                        optimalTravelTime: formatIntervalToSeconds(
+                            new Date(tripPattern.expectedEndTime),
+                            new Date(formattedDateTime),
+                        ),
                         isActive: true,
                     }
                     setEvent(newEvent)

--- a/src/components/Game/Game.tsx
+++ b/src/components/Game/Game.tsx
@@ -257,7 +257,7 @@ function Game({
                             return {
                                 stopPlace: stop,
                                 time: new Date(
-                                    (nextDep || d).expectedArrivalTime,
+                                    (d || nextDep).expectedArrivalTime,
                                 ),
                             }
                         })

--- a/src/lib/constants/queries.ts
+++ b/src/lib/constants/queries.ts
@@ -3,6 +3,7 @@ query getTripInfo($from: Location!, $to: Location!, $dateTime: DateTime!, $modes
   trip(from: $from, to: $to, numTripPatterns: 1, dateTime: $dateTime, modes: $modes) {
     tripPatterns {
       duration
+      expectedEndTime
       legs {
         fromPlace {
           name


### PR DESCRIPTION
## Pull Request Template

### PR Type 🍏

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] API
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation content changes
[ ] Tests
[ ] Other
```

[Kanban Link](https://www.notion.so/bekks/Total-reisetid-er-feil-bd87f295c4b640c8a062304db1eb6352?pvs=4)

### Context 🤷‍♀️

Selv om man reiser med optimal rute får man ikke 100 poeng. Dette skjer fordi måten total reisetid beregnes ikke er helt riktig.

### What's new? 👶

Total reisetid beregner nå fra starttiden som er satt av admin, ikke starttid til første del av reisen (som kommer fra journey planner).
Klokkeslett for ankomst per stoppested blir nå satt riktig. Tidligere var dette satt til klokkeslett for neste stopp, ikke nåværende.

### Screenshots 🖼️

Ingen bilder