### PR TITLE
remove travel tag static width

### DIFF
--- a/src/components/Game/components/TravelLegStart/TravelLegTag.tsx
+++ b/src/components/Game/components/TravelLegStart/TravelLegTag.tsx
@@ -30,7 +30,7 @@ export function TravelLegTag({
         transportMode === 'coach' ? 'bus' : transportMode
 
     return (
-        <div className="w-20 [&>*]:w-full mr-2">
+        <div className="[&>*]:w-full mr-2">
             <TravelTag
                 transport={
                     (correctedTransportMode as TravelLegProps['transport']) ??


### PR DESCRIPTION
## Pull Request Template

### PR Type 🍏

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] API
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation content changes
[ ] Tests
[ ] Other
```

[Kanban Link](https://www.notion.so/bekks/Fiks-travel-leg-st-rrelse-acaa2f7c6d5d4d00962ba0eb791c1125?pvs=4)

### Context 🤷‍♀️

Travel tag inneholder både symbolet for reisemåte og hvilken linje det er. Når navnet på linja, for eksempel NW192, er for langt krymper symbolet.

### What's new? 👶

Fjernet statisk width, som forårsaker feilen. Dette er et forslag til endring. Nå har travel tag dynamisk størrelse, avhengig av hvor mye tekst som vises i boksen. Entur.no gjør det samme, men ønsker vi dette?

### Screenshots 🖼️
![Skjermbilde 2024-07-29 kl  15 31 23](https://github.com/user-attachments/assets/7b470c11-6adb-4f1e-89fb-f02ebd84d2e4)


