### PR TITLE
Make entire previous event card clickable

### DIFF
--- a/src/app/(white)/admin/components/InactiveEventsList.tsx
+++ b/src/app/(white)/admin/components/InactiveEventsList.tsx
@@ -56,6 +56,7 @@ const InactiveEventsList: React.FC = (): JSX.Element => {
                     <BaseCard
                         key={event.eventId}
                         className="mb-4 max-h-20 flex-1 min-w-[200px] max-w-[480px] h-[80px] p-4 cursor-pointer hover:bg-gray-200 transform hover:-translate-y-0.5 transition-all duration-200 hover:shadow-lg"
+                        onClick={() => handleNavigateLeaderboard(event.eventId)}
                     >
                         <TravelHeader
                             className="max-w-full"
@@ -63,9 +64,6 @@ const InactiveEventsList: React.FC = (): JSX.Element => {
                             from={event.startLocationName}
                             to={event.endLocationNames[0] || ''}
                             noWrap={true}
-                            onClick={() =>
-                                handleNavigateLeaderboard(event.eventId)
-                            }
                         />
                     </BaseCard>
                     <Modal


### PR DESCRIPTION
## Pull Request Template

### PR Type 🍏

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] API
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation content changes
[ ] Tests
[ ] Other
```

[Kanban Link](https://www.notion.so/bekks/Hele-kortet-rundt-tidligere-spill-er-ikke-klikkbart-4ec1da35a0904785a5be0b1d5da8c548?pvs=4)

### Context 🤷‍♀️

Kortet som holder et tidligere spill i lista over tidligere spill er ikke klikkbart. Det er kun teksten i kortet som er klikkbart. Dette fører til at hvis et kort har tekst som ikke strekker seg helt ut, så vil det ikke være mulig å trykke på dette området, kun området med teksten.

### What's new? 👶

Describe what you have done and what has been implemented within this PR.

### Screenshots 🖼️

Bilder for å vise hvilke kort det er snakk om
![Skjermbilde 2024-07-29 kl  15 49 52](https://github.com/user-attachments/assets/79b548a6-9951-45c1-a368-b579387f01ab)
![Skjermbilde 2024-07-29 kl  15 49 43](https://github.com/user-attachments/assets/7550bfee-d469-4abd-a516-df7a63720b02)