### PR TITLE
ETU-68614 rotate public mapbox tokens for staging and prod

### DIFF
--- a/helm/entur-game-frontend/env/values-kub-ent-prd.yaml
+++ b/helm/entur-game-frontend/env/values-kub-ent-prd.yaml
@@ -15,4 +15,4 @@ common:
             - name: NEXTAUTH_URL
               value: 'https://entur-game.entur.org'
             - name: NEXT_PUBLIC_MAPBOX_TOKEN
-              value: 'pk.eyJ1IjoiZW50dXIiLCJhIjoiY2x6OWllZDNpMDQyNzJrczgydXhteWdrdCJ9.25MKjylrKRdojFLOQylIag'
+              value: 'pk.eyJ1IjoiZW50dXIiLCJhIjoiY21scnM4OXEzMGR2OTNlc2x6Ymo1bnpjdiJ9.L_ho4Ez-PMOnD3DSYlqSMw'

--- a/helm/entur-game-frontend/env/values-kub-ent-tst.yaml
+++ b/helm/entur-game-frontend/env/values-kub-ent-tst.yaml
@@ -15,4 +15,4 @@ common:
             - name: NEXTAUTH_URL
               value: 'https://entur-game.staging.entur.org'
             - name: NEXT_PUBLIC_MAPBOX_TOKEN
-              value: 'pk.eyJ1IjoiZW50dXIiLCJhIjoiY2x6OWlkZDBrMDhvbDJ4czdxMnVwMjJ4YiJ9.mng8swE3lk-TXdLbdOdv2Q'
+              value: 'pk.eyJ1IjoiZW50dXIiLCJhIjoiY21scnM2b2o5MGRubjNkc2xvb2hvMHZwNyJ9.h6Rbn_tkePanXs_rd-Mtdw'

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,9 +19,9 @@ export const MAP_BOX_TOKEN = (() => {
 
     switch (ENVIRONMENT) {
         case 'PROD':
-            return 'pk.eyJ1IjoiZW50dXIiLCJhIjoiY2x6OWllZDNpMDQyNzJrczgydXhteWdrdCJ9.25MKjylrKRdojFLOQylIag'
+            return 'pk.eyJ1IjoiZW50dXIiLCJhIjoiY21scnM4OXEzMGR2OTNlc2x6Ymo1bnpjdiJ9.L_ho4Ez-PMOnD3DSYlqSMw'
         case 'STAGING':
-            return 'pk.eyJ1IjoiZW50dXIiLCJhIjoiY2x6OWlkZDBrMDhvbDJ4czdxMnVwMjJ4YiJ9.mng8swE3lk-TXdLbdOdv2Q'
+            return 'pk.eyJ1IjoiZW50dXIiLCJhIjoiY21scnM2b2o5MGRubjNkc2xvb2hvMHZwNyJ9.h6Rbn_tkePanXs_rd-Mtdw'
         default:
             if (!ENV_MAP_BOX_TOKEN) throw Error('Mapbox token is not defined')
             return ENV_MAP_BOX_TOKEN as string


### PR DESCRIPTION
The tokens have not been rotated in a while, and is "leaked" according tok GitHub (whatever that means, the tokens are public). New tokens are created, old ones are revoked. And the tokens are scoped to only be accessible from the games respective domains for staging and prod.
